### PR TITLE
[FIX] - correct typos in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,9 @@ overflow-checks = false
 strip = true
 opt-level = "z"
 lto = true
-codegen-unts = 1
+codegen-units = 1
 panic = "abort"
+[profile.release.build-override]
+opt-level = "z"
+incremental = false
+codegen-units = 1


### PR DESCRIPTION
# Summary
- Correct typo in Cargo.toml for compiler optimizations

## Notes
 - checked the size of `vetoken.so` before and after applying the fixes and they're still the same