### PR TITLE
Address comments from internal audit

### DIFF
--- a/programs/vetoken/src/ins_v1/claim_from_distribution.rs
+++ b/programs/vetoken/src/ins_v1/claim_from_distribution.rs
@@ -13,7 +13,7 @@ use anchor_spl::{
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct ClaimFromDistributionArgs {
     amount: u64,
-    cosigned_msg: [u8; 32],
+    cosigned_msg: [u8; 32], // cosigned_msg is a sha256 hash of the message that was cosigned, it's per ns per claimant per message digest
 }
 
 #[derive(Accounts)]
@@ -34,7 +34,7 @@ pub struct ClaimFromDistribution<'info> {
 
     #[account(
       init,
-      seeds=[b"distribution_claim", ns.key().as_ref(), distribution.key().as_ref(), claimant.key().as_ref(), args.cosigned_msg.as_ref()],
+      seeds=[b"distribution_claim", ns.key().as_ref(), claimant.key().as_ref(), args.cosigned_msg.as_ref()],
       payer=payer,
       space=8+DistributionClaim::INIT_SPACE,
       bump,

--- a/programs/vetoken/src/ins_v1/unstake.rs
+++ b/programs/vetoken/src/ins_v1/unstake.rs
@@ -26,6 +26,7 @@ pub struct Unstake<'info> {
       mut,
       seeds=[b"lockup", ns.key().as_ref(), owner.key().as_ref()],
       has_one=ns,
+      has_one=owner,
       constraint = lockup.end_ts <= ns.now() @ CustomError::InvalidTimestamp,
       constraint = ns.lockup_amount >= lockup.amount @ CustomError::Overflow,
       bump,

--- a/programs/vetoken/src/states.rs
+++ b/programs/vetoken/src/states.rs
@@ -187,28 +187,6 @@ impl Proposal {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn winning_choice(&self) -> usize {
-        let choices = [
-            self.num_choice_0,
-            self.num_choice_1,
-            self.num_choice_2,
-            self.num_choice_3,
-            self.num_choice_4,
-            self.num_choice_5,
-        ];
-
-        let mut max_choice = 0;
-        let mut max_choice_idx = 0;
-        for (idx, choice) in choices.iter().enumerate() {
-            if *choice > max_choice {
-                max_choice = *choice;
-                max_choice_idx = idx;
-            }
-        }
-        max_choice_idx
-    }
-
     pub fn total_votes(&self) -> u64 {
         self.num_choice_0
             .checked_add(self.num_choice_1)
@@ -278,7 +256,7 @@ pub struct Distribution {
 #[account]
 #[derive(Copy, InitSpace)]
 pub struct DistributionClaim {
-    // Seeds: [b"distribution_claim", ns.key().as_ref(), distribution.key().as_ref(), claimant.key().as_ref(), args.cosigned_msg.as_ref()]
+    // Seeds: [b"distribution_claim", ns.key().as_ref(), claimant.key().as_ref(), args.cosigned_msg.as_ref()]
     pub ns: Pubkey,
     pub distribution: Pubkey,
     pub claimant: Pubkey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,12 +120,11 @@ export class VeTokenSDK {
     return pda;
   }
 
-  pdaDistributionClaim(distribution: PublicKey, claimant: PublicKey, cosignedMsg: string) {
+  pdaDistributionClaim(claimant: PublicKey, cosignedMsg: string) {
     const [pda] = PublicKey.findProgramAddressSync(
       [
         Buffer.from("distribution_claim"),
         this.pdaNamespace().toBuffer(),
-        distribution.toBuffer(),
         claimant.toBuffer(),
         createHash('sha256').update(cosignedMsg).digest(),
       ],
@@ -370,7 +369,7 @@ export class VeTokenSDK {
         claimant,
         cosigner1,
         cosigner2,
-        distributionClaim: this.pdaDistributionClaim(distribution, claimant, cosignedMsg),
+        distributionClaim: this.pdaDistributionClaim(claimant, cosignedMsg),
         delegatedTokenAccount,
         claimantTokenAccount: getAssociatedTokenAddressSync(
           this.tokenMint,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -645,7 +645,7 @@ describe("proposal", async () => {
     confirmed = await ctx.banksClient.tryProcessTransaction(tx);
     console.log(confirmed.meta?.logMessages);
     assert(confirmed.result === null);
-    const dc = await getDistributionClaim(ctx, sdk, sdk.pdaDistributionClaim(distribution, claimant.publicKey, cosignedMsg));
+    const dc = await getDistributionClaim(ctx, sdk, sdk.pdaDistributionClaim(claimant.publicKey, cosignedMsg));
     assert(dc);
     assert(dc.claimant.equals(claimant.publicKey));
     const claimantTokenAccount = await getToken(ctx, getAssociatedTokenAddressSync(TOKEN_MINT, claimant.publicKey, true));


### PR DESCRIPTION
- Add more comments around cosigned_msg
- Remove distributor from the distributionClaim seed, so that the claim rely more on the cosigned message and can cover more than one distribution
- Remove deadcode of winning_choice, which might introduce choices that might have the same number of votes.