### PR TITLE
Change bp to pct for voting power calcuation

### DIFF
--- a/programs/vetoken/src/errors.rs
+++ b/programs/vetoken/src/errors.rs
@@ -26,4 +26,10 @@ pub enum CustomError {
     CannotUpdateProposal,
     #[msg("Invalid URI")]
     InvalidURI,
+    #[msg("Invalid Namespace")]
+    InvalidNamespace,
+    #[msg("Invalid Lockup")]
+    InvalidLockup,
+    #[msg("Invalid Vote Record")]
+    InvalidVoteRecord,
 }

--- a/programs/vetoken/src/ins_v1/init_namespace.rs
+++ b/programs/vetoken/src/ins_v1/init_namespace.rs
@@ -1,4 +1,4 @@
-use crate::states::Namespace;
+use crate::{errors::CustomError, states::Namespace};
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::Mint;
 
@@ -38,13 +38,18 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, InitNamespace<'info>>) -> R
     ns.deployer = ctx.accounts.deployer.key();
 
     // Setting the default values and the security council can change
-    ns.lockup_default_target_rewards_bp = 10000;
-    ns.lockup_default_target_voting_bp = 10000; // 100%
+    ns.lockup_default_target_rewards_pct = 100; // 100% of the voting power
+    ns.lockup_default_target_voting_pct = 2000; // 2000%, i.e. 20x
     ns.lockup_min_duration = 86400 * 14; // 14 day in seconds
     ns.lockup_min_amount = 10 * 1_000_000; // ui amount is 10 assuming 6 decimals
     ns.lockup_max_saturation = 86400 * 365 * 4; // 4 years in seconds
     ns.proposal_min_voting_power_for_quorum = 10 * 1_000_000; // minimum participation voting power
-    ns.proposal_min_pass_bp = 6000; // 60%, the population is total_votes
+    ns.proposal_min_pass_pct = 60; // 60%, the population is total_votes
     ns.proposal_can_update_after_votes = false;
+
+    if !ns.valid() {
+        return Err(CustomError::InvalidNamespace.into());
+    }
+
     Ok(())
 }

--- a/programs/vetoken/src/ins_v1/init_proposal.rs
+++ b/programs/vetoken/src/ins_v1/init_proposal.rs
@@ -51,13 +51,14 @@ pub fn handle<'info>(
     proposal.owner = ctx.accounts.review_council.key();
     proposal.nonce = ns.proposal_nonce;
 
-    if !proposal.has_valid_uri() {
-        return Err(CustomError::InvalidURI.into());
+    if !proposal.valid() {
+        return Err(CustomError::InvalidProposalState.into());
     }
 
     ns.proposal_nonce = ns
         .proposal_nonce
         .checked_add(1)
         .expect("should not overflow");
+
     Ok(())
 }

--- a/programs/vetoken/src/ins_v1/stake.rs
+++ b/programs/vetoken/src/ins_v1/stake.rs
@@ -83,8 +83,8 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, Stake<'info>>, args: StakeA
     // only the first time staking can set the default values for target rewards and voting power
     // this is to prevent the staker from overriding what's set by stake_to by security council, if any
     if lockup.amount == 0 {
-        lockup.target_rewards_bp = ns.lockup_default_target_rewards_bp;
-        lockup.target_voting_bp = ns.lockup_default_target_voting_bp;
+        lockup.target_rewards_pct = ns.lockup_default_target_rewards_pct;
+        lockup.target_voting_pct = ns.lockup_default_target_voting_pct;
     }
 
     // Staker can only extend the lockup period, not reduce it.
@@ -104,6 +104,10 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, Stake<'info>>, args: StakeA
         .lockup_amount
         .checked_add(args.amount)
         .expect("should not overflow");
+
+    if !lockup.valid(ns) {
+        return Err(CustomError::InvalidLockup.into());
+    }
 
     Ok(())
 }

--- a/programs/vetoken/src/ins_v1/update_namespace.rs
+++ b/programs/vetoken/src/ins_v1/update_namespace.rs
@@ -1,4 +1,4 @@
-use crate::states::Namespace;
+use crate::{errors::CustomError, states::Namespace};
 use anchor_lang::prelude::*;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
@@ -6,13 +6,13 @@ pub struct UpdateNamespaceArgs {
     security_council: Pubkey,
     review_council: Pubkey,
 
-    lockup_default_target_rewards_bp: u16,
-    lockup_default_target_voting_bp: u16,
+    lockup_default_target_rewards_pct: u16,
+    lockup_default_target_voting_pct: u16,
     lockup_min_duration: i64,
     lockup_min_amount: u64,
     lockup_max_saturation: u64,
     proposal_min_voting_power_for_quorum: u64,
-    proposal_min_pass_bp: u16,
+    proposal_min_pass_pct: u16,
     proposal_can_update_after_votes: bool,
 }
 
@@ -37,14 +37,18 @@ pub fn handle<'info>(
 
     ns.security_council = args.security_council;
     ns.review_council = args.review_council;
-    ns.lockup_default_target_rewards_bp = args.lockup_default_target_rewards_bp;
-    ns.lockup_default_target_voting_bp = args.lockup_default_target_voting_bp;
+    ns.lockup_default_target_rewards_pct = args.lockup_default_target_rewards_pct;
+    ns.lockup_default_target_voting_pct = args.lockup_default_target_voting_pct;
     ns.lockup_min_duration = args.lockup_min_duration;
     ns.lockup_min_amount = args.lockup_min_amount;
     ns.lockup_max_saturation = args.lockup_max_saturation;
     ns.proposal_min_voting_power_for_quorum = args.proposal_min_voting_power_for_quorum;
-    ns.proposal_min_pass_bp = args.proposal_min_pass_bp;
+    ns.proposal_min_pass_pct = args.proposal_min_pass_pct;
     ns.proposal_can_update_after_votes = args.proposal_can_update_after_votes;
+
+    if !ns.valid() {
+        return Err(CustomError::InvalidNamespace.into());
+    }
 
     Ok(())
 }

--- a/programs/vetoken/src/ins_v1/update_proposal.rs
+++ b/programs/vetoken/src/ins_v1/update_proposal.rs
@@ -40,8 +40,9 @@ pub fn handle<'info>(
     proposal.start_ts = args.start_ts;
     proposal.end_ts = args.end_ts;
 
-    if !proposal.has_valid_uri() {
-        return Err(CustomError::InvalidURI.into());
+    if !proposal.valid() {
+        return Err(CustomError::InvalidProposalState.into());
     }
+
     Ok(())
 }

--- a/programs/vetoken/src/ins_v1/vote.rs
+++ b/programs/vetoken/src/ins_v1/vote.rs
@@ -64,5 +64,9 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, Vote<'info>>, args: VoteArg
     vote_record.voting_power = voting_power;
     vote_record.lockup = ctx.accounts.lockup.key();
 
+    if !vote_record.valid() {
+        return Err(CustomError::InvalidVoteRecord.into());
+    }
+
     Ok(())
 }

--- a/programs/vetoken/src/states.rs
+++ b/programs/vetoken/src/states.rs
@@ -1,6 +1,8 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
 use std::convert::TryInto;
 
+const MAX_VOTING_CHOICES: usize = 6;
+
 #[account]
 #[derive(Copy, InitSpace)]
 pub struct Namespace {
@@ -12,13 +14,13 @@ pub struct Namespace {
     pub security_council: Pubkey,
     pub review_council: Pubkey,
     pub override_now: i64,
-    pub lockup_default_target_rewards_bp: u16,
-    pub lockup_default_target_voting_bp: u16,
+    pub lockup_default_target_rewards_pct: u16,
+    pub lockup_default_target_voting_pct: u16,
     pub lockup_min_duration: i64,
     pub lockup_min_amount: u64,
     pub lockup_max_saturation: u64,
     pub proposal_min_voting_power_for_quorum: u64,
-    pub proposal_min_pass_bp: u16,
+    pub proposal_min_pass_pct: u16,
     pub proposal_can_update_after_votes: bool,
 
     // Realtime Stats
@@ -38,6 +40,18 @@ impl Namespace {
             .expect("we should be able to get the clock timestamp")
             .unix_timestamp
     }
+
+    pub fn valid(&self) -> bool {
+        self.lockup_min_duration > 0
+            && self.lockup_min_amount > 0
+            && self.lockup_max_saturation > (self.lockup_min_duration as u64)
+            && self.lockup_default_target_rewards_pct >= 100
+            && self.lockup_default_target_voting_pct >= 100
+            && self.lockup_default_target_voting_pct <= 2500 // max 25x
+            && self.proposal_min_voting_power_for_quorum > 0
+            && self.proposal_min_pass_pct > 0
+            && self.proposal_min_pass_pct <= 100
+    }
 }
 
 #[account]
@@ -51,8 +65,8 @@ pub struct Lockup {
     pub start_ts: i64,
     pub end_ts: i64,
 
-    pub target_rewards_bp: u16, // in bp
-    pub target_voting_bp: u16,  // in bp
+    pub target_rewards_pct: u16, // in percent
+    pub target_voting_pct: u16,  // in percent
 
     pub _padding: [u8; 240],
 }
@@ -64,21 +78,30 @@ impl Lockup {
             .expect("should not overflow")
     }
 
+    pub fn valid(&self, ns: &Namespace) -> bool {
+        self.amount >= ns.lockup_min_amount
+            && self.start_ts > 0
+            && self.end_ts >= self.min_end_ts(ns)
+            && self.end_ts >= self.start_ts
+            && self.target_voting_pct >= 100
+            && self.target_voting_pct <= 2500 // max 25x
+    }
+
     /*
-     * Linear decay of the voting power based on the target_voting_bp
+     * Linear decay of the voting power based on the target_voting_pct
      *                  Voting Power
      *                   ^
-     *                   |
-     * Max Voting Power  |  \
-     *                   |   \
-     *                   |    \
-     *                   |     \
-     *                   |      \
-     *                   |       \
-     *                   |        \
-     *                   |         \
-     *                   +---------------------> Time
-     *                  Start_ts           End_ts
+     *                   |           ----
+     * Max Voting Power  |          /
+     *                   |         /
+     *                   |        /
+     *                   |       /
+     *                   |      /
+     *                   |     /
+     *             100%  |    /
+     *                   | ---
+     *                   +---------------------> Lockup Remaining Time
+     *                     MinTime   MaxTime
      */
     pub fn voting_power(&self, ns: &Namespace) -> u64 {
         let now = ns.now();
@@ -87,26 +110,34 @@ impl Lockup {
             return 0;
         }
 
-        let max_voting_power = (self.amount as u128 * self.target_voting_bp as u128) / 10000;
+        let max_voting_power = (self.amount as u128 * self.target_voting_pct as u128) / 100;
 
         let remaining_time = u128::min(
             ns.lockup_max_saturation as u128,
             (self.end_ts - now) as u128,
         );
 
-        (max_voting_power * remaining_time / ns.lockup_max_saturation as u128)
-            .try_into()
-            .expect("should not overflow")
+        if remaining_time <= ns.lockup_min_duration as u128 {
+            return self.amount; // minimal 100% of the amount
+        }
+
+        let amount = self.amount as u128;
+
+        let ret = amount
+            + (max_voting_power - amount) * (remaining_time - ns.lockup_min_duration as u128)
+                / ((ns.lockup_max_saturation - ns.lockup_min_duration as u64) as u128);
+
+        ret.try_into().expect("should not overflow")
     }
 
-    // rewards_power is the voting power that can receive rewards based on the target_rewards_bp
+    // rewards_power is the voting power that can receive rewards based on the target_rewards_pct
     // it's not used in this program, but will be consumed by other programs
     #[allow(dead_code)]
     pub fn rewards_power(&self, ns: &Namespace) -> u64 {
         self.voting_power(ns)
-            .checked_mul(self.target_rewards_bp as u64)
+            .checked_mul(self.target_rewards_pct as u64)
             .expect("should not overflow")
-            .checked_div(10000)
+            .checked_div(100)
             .expect("should not overflow")
     }
 }
@@ -122,7 +153,7 @@ pub struct Proposal {
     pub start_ts: i64,
     pub end_ts: i64,
     pub status: u8,
-    pub voting_power_choices: [u64; 6], // cumulative voting power for each choice, we use max of 6 choices
+    pub voting_power_choices: [u64; MAX_VOTING_CHOICES], // cumulative voting power for each choice
 
     #[max_len(256)]
     pub uri: String,
@@ -134,6 +165,10 @@ impl Proposal {
     pub const STATUS_CREATED: u8 = 0;
     pub const STATUS_ACTIVATED: u8 = 1; // voting passed the minimum participation
     pub const STATUS_PASSED: u8 = 2;
+
+    pub fn valid(&self) -> bool {
+        self.uri.len() <= 255 && self.start_ts <= self.end_ts
+    }
 
     pub fn set_status(&mut self, ns: &Namespace, override_status: Option<u8>) {
         if override_status.is_some() {
@@ -188,17 +223,13 @@ impl Proposal {
         }
         let pass_threshold = self
             .total_voting_power()
-            .checked_mul(ns.proposal_min_pass_bp as u64)
+            .checked_mul(ns.proposal_min_pass_pct as u64)
             .expect("should not overflow")
-            .checked_div(10000)
+            .checked_div(100)
             .expect("should not overflow");
         self.voting_power_choices
             .iter()
             .any(|&choice| choice > pass_threshold)
-    }
-
-    pub fn has_valid_uri(&self) -> bool {
-        self.uri.len() <= 255
     }
 }
 
@@ -215,6 +246,12 @@ pub struct VoteRecord {
     pub voting_power: u64,
 
     pub _padding: [u8; 240],
+}
+
+impl VoteRecord {
+    pub fn valid(&self) -> bool {
+        (self.choice as usize) < MAX_VOTING_CHOICES
+    }
 }
 
 #[account]
@@ -260,13 +297,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1717796555,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
                     lockup_min_duration: 86400,
                     lockup_min_amount: 1000,
                     lockup_max_saturation: 864000,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -278,8 +315,8 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
-                    target_rewards_bp: 1000,
-                    target_voting_bp: 5000,
+                    target_rewards_pct: 1000,
+                    target_voting_pct: 5000,
                     _padding: [0; 240],
                 },
                 0, // end_ts expired, because override_now > end_ts
@@ -292,13 +329,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
                     lockup_min_duration: 86400,
                     lockup_min_amount: 1000,
-                    lockup_max_saturation: 86400,
+                    lockup_max_saturation: 86400 * 365 * 4,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -309,12 +346,12 @@ mod tests {
                     owner: Pubkey::new_from_array([0; 32]),
                     amount: 10000,
                     start_ts: 0,
-                    end_ts: 86400,
-                    target_rewards_bp: 5000,
-                    target_voting_bp: 1000,
+                    end_ts: 86400 * 14,
+                    target_rewards_pct: 100,
+                    target_voting_pct: 2000,
                     _padding: [0; 240],
                 },
-                999, //  should be closer to 10% (target_voting_bp) of the amount
+                11692,
             ),
             // Add more test cases here...
             (
@@ -325,13 +362,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1717796555,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
                     lockup_min_duration: 86400,
                     lockup_min_amount: 1000,
                     lockup_max_saturation: 864000,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -343,11 +380,11 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
-                    target_rewards_bp: 0,
-                    target_voting_bp: 0,
+                    target_rewards_pct: 100,
+                    target_voting_pct: 2000,
                     _padding: [0; 240],
                 },
-                0, // 0 because of the target_rewards_bp
+                0, // 0 because of the target_rewards_pct
             ),
             (
                 "Case 4",
@@ -357,13 +394,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
                     lockup_min_duration: 86400,
                     lockup_min_amount: 1000,
                     lockup_max_saturation: 86400,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -375,11 +412,11 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
-                    target_rewards_bp: 5000,
-                    target_voting_bp: 40000,
+                    target_rewards_pct: 100,
+                    target_voting_pct: 2000,
                     _padding: [0; 240],
                 },
-                39999, //  should be closer to 400% (target_voting_bp) of the amount
+                10000, // because we just hit the minimal duration, thus only getting 100% of the amount
             ),
             (
                 "Case 5",
@@ -389,13 +426,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1717796555,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
-                    lockup_min_duration: 86400,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
+                    lockup_min_duration: 3600 * 24 * 14,
                     lockup_min_amount: 1000,
                     lockup_max_saturation: 126144000,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -406,12 +443,12 @@ mod tests {
                     owner: Pubkey::new_from_array([0; 32]),
                     amount: 10000,
                     start_ts: 0,
-                    end_ts: 1717796555 + 3600 * 24 * 14,
-                    target_rewards_bp: 5000,
-                    target_voting_bp: 40000,
+                    end_ts: 1717796555 + 3600 * 24 * 180,
+                    target_rewards_pct: 100,
+                    target_voting_pct: 2000,
                     _padding: [0; 240],
                 },
-                383, //  should be closer to 14 days out of the 4 years satuation
+                31811, //  should be closer to 100% + (0.5 / 4) * 2000%
             ),
             (
                 "Case 6",
@@ -421,13 +458,13 @@ mod tests {
                     security_council: Pubkey::new_from_array([0; 32]),
                     review_council: Pubkey::new_from_array([0; 32]),
                     override_now: 1717796555,
-                    lockup_default_target_rewards_bp: 1000,
-                    lockup_default_target_voting_bp: 5000,
-                    lockup_min_duration: 86400,
+                    lockup_default_target_rewards_pct: 100,
+                    lockup_default_target_voting_pct: 2000,
+                    lockup_min_duration: 86400 * 14,
                     lockup_min_amount: 1000,
                     lockup_max_saturation: 126144000,
                     proposal_min_voting_power_for_quorum: 10000,
-                    proposal_min_pass_bp: 6000,
+                    proposal_min_pass_pct: 60,
                     proposal_can_update_after_votes: true,
                     lockup_amount: 10000,
                     proposal_nonce: 0,
@@ -438,12 +475,12 @@ mod tests {
                     owner: Pubkey::new_from_array([0; 32]),
                     amount: 10000,
                     start_ts: 0,
-                    end_ts: 1717796555 + 3600 * 24 * 365,
-                    target_rewards_bp: 5000,
-                    target_voting_bp: 40000,
+                    end_ts: 1717796555 + 3600 * 24 * 365 * 3 / 2,
+                    target_rewards_pct: 100,
+                    target_voting_pct: 2000,
                     _padding: [0; 240],
                 },
-                10000, //  should be closer to 1 year out of the 4 years satuation
+                80100, //  should be closer to 8x of the amount
             ),
         ];
 
@@ -461,13 +498,13 @@ mod tests {
             security_council: Pubkey::new_from_array([0; 32]),
             review_council: Pubkey::new_from_array([0; 32]),
             override_now: 1,
-            lockup_default_target_rewards_bp: 1000,
-            lockup_default_target_voting_bp: 5000,
+            lockup_default_target_rewards_pct: 100,
+            lockup_default_target_voting_pct: 5000,
             lockup_min_duration: 86400,
             lockup_min_amount: 1000,
             lockup_max_saturation: 86400,
             proposal_min_voting_power_for_quorum: 100000,
-            proposal_min_pass_bp: 6000,
+            proposal_min_pass_pct: 60,
             proposal_can_update_after_votes: true,
             lockup_amount: 10000,
             proposal_nonce: 0,
@@ -496,13 +533,13 @@ mod tests {
             security_council: Pubkey::new_from_array([0; 32]),
             review_council: Pubkey::new_from_array([0; 32]),
             override_now: 90, // now() < proposal.end_ts
-            lockup_default_target_rewards_bp: 1000,
-            lockup_default_target_voting_bp: 5000,
+            lockup_default_target_rewards_pct: 100,
+            lockup_default_target_voting_pct: 5000,
             lockup_min_duration: 86400,
             lockup_min_amount: 1000,
             lockup_max_saturation: 86400,
             proposal_min_voting_power_for_quorum: 100,
-            proposal_min_pass_bp: 6000,
+            proposal_min_pass_pct: 60,
             proposal_can_update_after_votes: true,
             lockup_amount: 10000,
             proposal_nonce: 0,
@@ -531,13 +568,13 @@ mod tests {
             security_council: Pubkey::new_from_array([0; 32]),
             review_council: Pubkey::new_from_array([0; 32]),
             override_now: 101,
-            lockup_default_target_rewards_bp: 1000,
-            lockup_default_target_voting_bp: 5000,
+            lockup_default_target_rewards_pct: 100,
+            lockup_default_target_voting_pct: 5000,
             lockup_min_duration: 86400,
             lockup_min_amount: 1000,
             lockup_max_saturation: 86400,
             proposal_min_voting_power_for_quorum: 100,
-            proposal_min_pass_bp: 6000,
+            proposal_min_pass_pct: 60,
             proposal_can_update_after_votes: true,
             lockup_amount: 10000,
             proposal_nonce: 0,

--- a/src/generated/accounts/Lockup.ts
+++ b/src/generated/accounts/Lockup.ts
@@ -10,8 +10,8 @@ export interface LockupFields {
   amount: BN
   startTs: BN
   endTs: BN
-  targetRewardsBp: number
-  targetVotingBp: number
+  targetRewardsPct: number
+  targetVotingPct: number
   padding: Array<number>
 }
 
@@ -21,8 +21,8 @@ export interface LockupJSON {
   amount: string
   startTs: string
   endTs: string
-  targetRewardsBp: number
-  targetVotingBp: number
+  targetRewardsPct: number
+  targetVotingPct: number
   padding: Array<number>
 }
 
@@ -32,8 +32,8 @@ export class Lockup {
   readonly amount: BN
   readonly startTs: BN
   readonly endTs: BN
-  readonly targetRewardsBp: number
-  readonly targetVotingBp: number
+  readonly targetRewardsPct: number
+  readonly targetVotingPct: number
   readonly padding: Array<number>
 
   static readonly discriminator = Buffer.from([1, 45, 32, 32, 57, 81, 88, 67])
@@ -44,8 +44,8 @@ export class Lockup {
     borsh.u64("amount"),
     borsh.i64("startTs"),
     borsh.i64("endTs"),
-    borsh.u16("targetRewardsBp"),
-    borsh.u16("targetVotingBp"),
+    borsh.u16("targetRewardsPct"),
+    borsh.u16("targetVotingPct"),
     borsh.array(borsh.u8(), 240, "padding"),
   ])
 
@@ -55,8 +55,8 @@ export class Lockup {
     this.amount = fields.amount
     this.startTs = fields.startTs
     this.endTs = fields.endTs
-    this.targetRewardsBp = fields.targetRewardsBp
-    this.targetVotingBp = fields.targetVotingBp
+    this.targetRewardsPct = fields.targetRewardsPct
+    this.targetVotingPct = fields.targetVotingPct
     this.padding = fields.padding
   }
 
@@ -109,8 +109,8 @@ export class Lockup {
       amount: dec.amount,
       startTs: dec.startTs,
       endTs: dec.endTs,
-      targetRewardsBp: dec.targetRewardsBp,
-      targetVotingBp: dec.targetVotingBp,
+      targetRewardsPct: dec.targetRewardsPct,
+      targetVotingPct: dec.targetVotingPct,
       padding: dec.padding,
     })
   }
@@ -122,8 +122,8 @@ export class Lockup {
       amount: this.amount.toString(),
       startTs: this.startTs.toString(),
       endTs: this.endTs.toString(),
-      targetRewardsBp: this.targetRewardsBp,
-      targetVotingBp: this.targetVotingBp,
+      targetRewardsPct: this.targetRewardsPct,
+      targetVotingPct: this.targetVotingPct,
       padding: this.padding,
     }
   }
@@ -135,8 +135,8 @@ export class Lockup {
       amount: new BN(obj.amount),
       startTs: new BN(obj.startTs),
       endTs: new BN(obj.endTs),
-      targetRewardsBp: obj.targetRewardsBp,
-      targetVotingBp: obj.targetVotingBp,
+      targetRewardsPct: obj.targetRewardsPct,
+      targetVotingPct: obj.targetVotingPct,
       padding: obj.padding,
     })
   }

--- a/src/generated/accounts/Namespace.ts
+++ b/src/generated/accounts/Namespace.ts
@@ -10,13 +10,13 @@ export interface NamespaceFields {
   securityCouncil: PublicKey
   reviewCouncil: PublicKey
   overrideNow: BN
-  lockupDefaultTargetRewardsBp: number
-  lockupDefaultTargetVotingBp: number
+  lockupDefaultTargetRewardsPct: number
+  lockupDefaultTargetVotingPct: number
   lockupMinDuration: BN
   lockupMinAmount: BN
   lockupMaxSaturation: BN
   proposalMinVotingPowerForQuorum: BN
-  proposalMinPassBp: number
+  proposalMinPassPct: number
   proposalCanUpdateAfterVotes: boolean
   lockupAmount: BN
   proposalNonce: number
@@ -29,13 +29,13 @@ export interface NamespaceJSON {
   securityCouncil: string
   reviewCouncil: string
   overrideNow: string
-  lockupDefaultTargetRewardsBp: number
-  lockupDefaultTargetVotingBp: number
+  lockupDefaultTargetRewardsPct: number
+  lockupDefaultTargetVotingPct: number
   lockupMinDuration: string
   lockupMinAmount: string
   lockupMaxSaturation: string
   proposalMinVotingPowerForQuorum: string
-  proposalMinPassBp: number
+  proposalMinPassPct: number
   proposalCanUpdateAfterVotes: boolean
   lockupAmount: string
   proposalNonce: number
@@ -48,13 +48,13 @@ export class Namespace {
   readonly securityCouncil: PublicKey
   readonly reviewCouncil: PublicKey
   readonly overrideNow: BN
-  readonly lockupDefaultTargetRewardsBp: number
-  readonly lockupDefaultTargetVotingBp: number
+  readonly lockupDefaultTargetRewardsPct: number
+  readonly lockupDefaultTargetVotingPct: number
   readonly lockupMinDuration: BN
   readonly lockupMinAmount: BN
   readonly lockupMaxSaturation: BN
   readonly proposalMinVotingPowerForQuorum: BN
-  readonly proposalMinPassBp: number
+  readonly proposalMinPassPct: number
   readonly proposalCanUpdateAfterVotes: boolean
   readonly lockupAmount: BN
   readonly proposalNonce: number
@@ -70,13 +70,13 @@ export class Namespace {
     borsh.publicKey("securityCouncil"),
     borsh.publicKey("reviewCouncil"),
     borsh.i64("overrideNow"),
-    borsh.u16("lockupDefaultTargetRewardsBp"),
-    borsh.u16("lockupDefaultTargetVotingBp"),
+    borsh.u16("lockupDefaultTargetRewardsPct"),
+    borsh.u16("lockupDefaultTargetVotingPct"),
     borsh.i64("lockupMinDuration"),
     borsh.u64("lockupMinAmount"),
     borsh.u64("lockupMaxSaturation"),
     borsh.u64("proposalMinVotingPowerForQuorum"),
-    borsh.u16("proposalMinPassBp"),
+    borsh.u16("proposalMinPassPct"),
     borsh.bool("proposalCanUpdateAfterVotes"),
     borsh.u64("lockupAmount"),
     borsh.u32("proposalNonce"),
@@ -89,14 +89,14 @@ export class Namespace {
     this.securityCouncil = fields.securityCouncil
     this.reviewCouncil = fields.reviewCouncil
     this.overrideNow = fields.overrideNow
-    this.lockupDefaultTargetRewardsBp = fields.lockupDefaultTargetRewardsBp
-    this.lockupDefaultTargetVotingBp = fields.lockupDefaultTargetVotingBp
+    this.lockupDefaultTargetRewardsPct = fields.lockupDefaultTargetRewardsPct
+    this.lockupDefaultTargetVotingPct = fields.lockupDefaultTargetVotingPct
     this.lockupMinDuration = fields.lockupMinDuration
     this.lockupMinAmount = fields.lockupMinAmount
     this.lockupMaxSaturation = fields.lockupMaxSaturation
     this.proposalMinVotingPowerForQuorum =
       fields.proposalMinVotingPowerForQuorum
-    this.proposalMinPassBp = fields.proposalMinPassBp
+    this.proposalMinPassPct = fields.proposalMinPassPct
     this.proposalCanUpdateAfterVotes = fields.proposalCanUpdateAfterVotes
     this.lockupAmount = fields.lockupAmount
     this.proposalNonce = fields.proposalNonce
@@ -152,13 +152,13 @@ export class Namespace {
       securityCouncil: dec.securityCouncil,
       reviewCouncil: dec.reviewCouncil,
       overrideNow: dec.overrideNow,
-      lockupDefaultTargetRewardsBp: dec.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: dec.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: dec.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: dec.lockupDefaultTargetVotingPct,
       lockupMinDuration: dec.lockupMinDuration,
       lockupMinAmount: dec.lockupMinAmount,
       lockupMaxSaturation: dec.lockupMaxSaturation,
       proposalMinVotingPowerForQuorum: dec.proposalMinVotingPowerForQuorum,
-      proposalMinPassBp: dec.proposalMinPassBp,
+      proposalMinPassPct: dec.proposalMinPassPct,
       proposalCanUpdateAfterVotes: dec.proposalCanUpdateAfterVotes,
       lockupAmount: dec.lockupAmount,
       proposalNonce: dec.proposalNonce,
@@ -173,14 +173,14 @@ export class Namespace {
       securityCouncil: this.securityCouncil.toString(),
       reviewCouncil: this.reviewCouncil.toString(),
       overrideNow: this.overrideNow.toString(),
-      lockupDefaultTargetRewardsBp: this.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: this.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: this.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: this.lockupDefaultTargetVotingPct,
       lockupMinDuration: this.lockupMinDuration.toString(),
       lockupMinAmount: this.lockupMinAmount.toString(),
       lockupMaxSaturation: this.lockupMaxSaturation.toString(),
       proposalMinVotingPowerForQuorum:
         this.proposalMinVotingPowerForQuorum.toString(),
-      proposalMinPassBp: this.proposalMinPassBp,
+      proposalMinPassPct: this.proposalMinPassPct,
       proposalCanUpdateAfterVotes: this.proposalCanUpdateAfterVotes,
       lockupAmount: this.lockupAmount.toString(),
       proposalNonce: this.proposalNonce,
@@ -195,15 +195,15 @@ export class Namespace {
       securityCouncil: new PublicKey(obj.securityCouncil),
       reviewCouncil: new PublicKey(obj.reviewCouncil),
       overrideNow: new BN(obj.overrideNow),
-      lockupDefaultTargetRewardsBp: obj.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: obj.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: obj.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: obj.lockupDefaultTargetVotingPct,
       lockupMinDuration: new BN(obj.lockupMinDuration),
       lockupMinAmount: new BN(obj.lockupMinAmount),
       lockupMaxSaturation: new BN(obj.lockupMaxSaturation),
       proposalMinVotingPowerForQuorum: new BN(
         obj.proposalMinVotingPowerForQuorum
       ),
-      proposalMinPassBp: obj.proposalMinPassBp,
+      proposalMinPassPct: obj.proposalMinPassPct,
       proposalCanUpdateAfterVotes: obj.proposalCanUpdateAfterVotes,
       lockupAmount: new BN(obj.lockupAmount),
       proposalNonce: obj.proposalNonce,

--- a/src/generated/errors/custom.ts
+++ b/src/generated/errors/custom.ts
@@ -11,6 +11,9 @@ export type CustomError =
   | Overflow
   | CannotUpdateProposal
   | InvalidURI
+  | InvalidNamespace
+  | InvalidLockup
+  | InvalidVoteRecord
 
 export class InvalidOwner extends Error {
   static readonly code = 6000
@@ -144,6 +147,39 @@ export class InvalidURI extends Error {
   }
 }
 
+export class InvalidNamespace extends Error {
+  static readonly code = 6012
+  readonly code = 6012
+  readonly name = "InvalidNamespace"
+  readonly msg = "Invalid Namespace"
+
+  constructor(readonly logs?: string[]) {
+    super("6012: Invalid Namespace")
+  }
+}
+
+export class InvalidLockup extends Error {
+  static readonly code = 6013
+  readonly code = 6013
+  readonly name = "InvalidLockup"
+  readonly msg = "Invalid Lockup"
+
+  constructor(readonly logs?: string[]) {
+    super("6013: Invalid Lockup")
+  }
+}
+
+export class InvalidVoteRecord extends Error {
+  static readonly code = 6014
+  readonly code = 6014
+  readonly name = "InvalidVoteRecord"
+  readonly msg = "Invalid Vote Record"
+
+  constructor(readonly logs?: string[]) {
+    super("6014: Invalid Vote Record")
+  }
+}
+
 export function fromCode(code: number, logs?: string[]): CustomError | null {
   switch (code) {
     case 6000:
@@ -170,6 +206,12 @@ export function fromCode(code: number, logs?: string[]): CustomError | null {
       return new CannotUpdateProposal(logs)
     case 6011:
       return new InvalidURI(logs)
+    case 6012:
+      return new InvalidNamespace(logs)
+    case 6013:
+      return new InvalidLockup(logs)
+    case 6014:
+      return new InvalidVoteRecord(logs)
   }
 
   return null

--- a/src/generated/types/StakeToArgs.ts
+++ b/src/generated/types/StakeToArgs.ts
@@ -6,29 +6,29 @@ import * as borsh from "@coral-xyz/borsh"
 export interface StakeToArgsFields {
   amount: BN
   endTs: BN
-  disableRewardsBp: boolean
+  disableRewards: boolean
 }
 
 export interface StakeToArgsJSON {
   amount: string
   endTs: string
-  disableRewardsBp: boolean
+  disableRewards: boolean
 }
 
 export class StakeToArgs {
   readonly amount: BN
   readonly endTs: BN
-  readonly disableRewardsBp: boolean
+  readonly disableRewards: boolean
 
   constructor(fields: StakeToArgsFields) {
     this.amount = fields.amount
     this.endTs = fields.endTs
-    this.disableRewardsBp = fields.disableRewardsBp
+    this.disableRewards = fields.disableRewards
   }
 
   static layout(property?: string) {
     return borsh.struct(
-      [borsh.u64("amount"), borsh.i64("endTs"), borsh.bool("disableRewardsBp")],
+      [borsh.u64("amount"), borsh.i64("endTs"), borsh.bool("disableRewards")],
       property
     )
   }
@@ -38,7 +38,7 @@ export class StakeToArgs {
     return new StakeToArgs({
       amount: obj.amount,
       endTs: obj.endTs,
-      disableRewardsBp: obj.disableRewardsBp,
+      disableRewards: obj.disableRewards,
     })
   }
 
@@ -46,7 +46,7 @@ export class StakeToArgs {
     return {
       amount: fields.amount,
       endTs: fields.endTs,
-      disableRewardsBp: fields.disableRewardsBp,
+      disableRewards: fields.disableRewards,
     }
   }
 
@@ -54,7 +54,7 @@ export class StakeToArgs {
     return {
       amount: this.amount.toString(),
       endTs: this.endTs.toString(),
-      disableRewardsBp: this.disableRewardsBp,
+      disableRewards: this.disableRewards,
     }
   }
 
@@ -62,7 +62,7 @@ export class StakeToArgs {
     return new StakeToArgs({
       amount: new BN(obj.amount),
       endTs: new BN(obj.endTs),
-      disableRewardsBp: obj.disableRewardsBp,
+      disableRewards: obj.disableRewards,
     })
   }
 

--- a/src/generated/types/UpdateNamespaceArgs.ts
+++ b/src/generated/types/UpdateNamespaceArgs.ts
@@ -6,52 +6,52 @@ import * as borsh from "@coral-xyz/borsh"
 export interface UpdateNamespaceArgsFields {
   securityCouncil: PublicKey
   reviewCouncil: PublicKey
-  lockupDefaultTargetRewardsBp: number
-  lockupDefaultTargetVotingBp: number
+  lockupDefaultTargetRewardsPct: number
+  lockupDefaultTargetVotingPct: number
   lockupMinDuration: BN
   lockupMinAmount: BN
   lockupMaxSaturation: BN
   proposalMinVotingPowerForQuorum: BN
-  proposalMinPassBp: number
+  proposalMinPassPct: number
   proposalCanUpdateAfterVotes: boolean
 }
 
 export interface UpdateNamespaceArgsJSON {
   securityCouncil: string
   reviewCouncil: string
-  lockupDefaultTargetRewardsBp: number
-  lockupDefaultTargetVotingBp: number
+  lockupDefaultTargetRewardsPct: number
+  lockupDefaultTargetVotingPct: number
   lockupMinDuration: string
   lockupMinAmount: string
   lockupMaxSaturation: string
   proposalMinVotingPowerForQuorum: string
-  proposalMinPassBp: number
+  proposalMinPassPct: number
   proposalCanUpdateAfterVotes: boolean
 }
 
 export class UpdateNamespaceArgs {
   readonly securityCouncil: PublicKey
   readonly reviewCouncil: PublicKey
-  readonly lockupDefaultTargetRewardsBp: number
-  readonly lockupDefaultTargetVotingBp: number
+  readonly lockupDefaultTargetRewardsPct: number
+  readonly lockupDefaultTargetVotingPct: number
   readonly lockupMinDuration: BN
   readonly lockupMinAmount: BN
   readonly lockupMaxSaturation: BN
   readonly proposalMinVotingPowerForQuorum: BN
-  readonly proposalMinPassBp: number
+  readonly proposalMinPassPct: number
   readonly proposalCanUpdateAfterVotes: boolean
 
   constructor(fields: UpdateNamespaceArgsFields) {
     this.securityCouncil = fields.securityCouncil
     this.reviewCouncil = fields.reviewCouncil
-    this.lockupDefaultTargetRewardsBp = fields.lockupDefaultTargetRewardsBp
-    this.lockupDefaultTargetVotingBp = fields.lockupDefaultTargetVotingBp
+    this.lockupDefaultTargetRewardsPct = fields.lockupDefaultTargetRewardsPct
+    this.lockupDefaultTargetVotingPct = fields.lockupDefaultTargetVotingPct
     this.lockupMinDuration = fields.lockupMinDuration
     this.lockupMinAmount = fields.lockupMinAmount
     this.lockupMaxSaturation = fields.lockupMaxSaturation
     this.proposalMinVotingPowerForQuorum =
       fields.proposalMinVotingPowerForQuorum
-    this.proposalMinPassBp = fields.proposalMinPassBp
+    this.proposalMinPassPct = fields.proposalMinPassPct
     this.proposalCanUpdateAfterVotes = fields.proposalCanUpdateAfterVotes
   }
 
@@ -60,13 +60,13 @@ export class UpdateNamespaceArgs {
       [
         borsh.publicKey("securityCouncil"),
         borsh.publicKey("reviewCouncil"),
-        borsh.u16("lockupDefaultTargetRewardsBp"),
-        borsh.u16("lockupDefaultTargetVotingBp"),
+        borsh.u16("lockupDefaultTargetRewardsPct"),
+        borsh.u16("lockupDefaultTargetVotingPct"),
         borsh.i64("lockupMinDuration"),
         borsh.u64("lockupMinAmount"),
         borsh.u64("lockupMaxSaturation"),
         borsh.u64("proposalMinVotingPowerForQuorum"),
-        borsh.u16("proposalMinPassBp"),
+        borsh.u16("proposalMinPassPct"),
         borsh.bool("proposalCanUpdateAfterVotes"),
       ],
       property
@@ -78,13 +78,13 @@ export class UpdateNamespaceArgs {
     return new UpdateNamespaceArgs({
       securityCouncil: obj.securityCouncil,
       reviewCouncil: obj.reviewCouncil,
-      lockupDefaultTargetRewardsBp: obj.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: obj.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: obj.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: obj.lockupDefaultTargetVotingPct,
       lockupMinDuration: obj.lockupMinDuration,
       lockupMinAmount: obj.lockupMinAmount,
       lockupMaxSaturation: obj.lockupMaxSaturation,
       proposalMinVotingPowerForQuorum: obj.proposalMinVotingPowerForQuorum,
-      proposalMinPassBp: obj.proposalMinPassBp,
+      proposalMinPassPct: obj.proposalMinPassPct,
       proposalCanUpdateAfterVotes: obj.proposalCanUpdateAfterVotes,
     })
   }
@@ -93,13 +93,13 @@ export class UpdateNamespaceArgs {
     return {
       securityCouncil: fields.securityCouncil,
       reviewCouncil: fields.reviewCouncil,
-      lockupDefaultTargetRewardsBp: fields.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: fields.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: fields.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: fields.lockupDefaultTargetVotingPct,
       lockupMinDuration: fields.lockupMinDuration,
       lockupMinAmount: fields.lockupMinAmount,
       lockupMaxSaturation: fields.lockupMaxSaturation,
       proposalMinVotingPowerForQuorum: fields.proposalMinVotingPowerForQuorum,
-      proposalMinPassBp: fields.proposalMinPassBp,
+      proposalMinPassPct: fields.proposalMinPassPct,
       proposalCanUpdateAfterVotes: fields.proposalCanUpdateAfterVotes,
     }
   }
@@ -108,14 +108,14 @@ export class UpdateNamespaceArgs {
     return {
       securityCouncil: this.securityCouncil.toString(),
       reviewCouncil: this.reviewCouncil.toString(),
-      lockupDefaultTargetRewardsBp: this.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: this.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: this.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: this.lockupDefaultTargetVotingPct,
       lockupMinDuration: this.lockupMinDuration.toString(),
       lockupMinAmount: this.lockupMinAmount.toString(),
       lockupMaxSaturation: this.lockupMaxSaturation.toString(),
       proposalMinVotingPowerForQuorum:
         this.proposalMinVotingPowerForQuorum.toString(),
-      proposalMinPassBp: this.proposalMinPassBp,
+      proposalMinPassPct: this.proposalMinPassPct,
       proposalCanUpdateAfterVotes: this.proposalCanUpdateAfterVotes,
     }
   }
@@ -124,15 +124,15 @@ export class UpdateNamespaceArgs {
     return new UpdateNamespaceArgs({
       securityCouncil: new PublicKey(obj.securityCouncil),
       reviewCouncil: new PublicKey(obj.reviewCouncil),
-      lockupDefaultTargetRewardsBp: obj.lockupDefaultTargetRewardsBp,
-      lockupDefaultTargetVotingBp: obj.lockupDefaultTargetVotingBp,
+      lockupDefaultTargetRewardsPct: obj.lockupDefaultTargetRewardsPct,
+      lockupDefaultTargetVotingPct: obj.lockupDefaultTargetVotingPct,
       lockupMinDuration: new BN(obj.lockupMinDuration),
       lockupMinAmount: new BN(obj.lockupMinAmount),
       lockupMaxSaturation: new BN(obj.lockupMaxSaturation),
       proposalMinVotingPowerForQuorum: new BN(
         obj.proposalMinVotingPowerForQuorum
       ),
-      proposalMinPassBp: obj.proposalMinPassBp,
+      proposalMinPassPct: obj.proposalMinPassPct,
       proposalCanUpdateAfterVotes: obj.proposalCanUpdateAfterVotes,
     })
   }

--- a/src/idl/vetoken.json
+++ b/src/idl/vetoken.json
@@ -476,11 +476,11 @@
             "type": "i64"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -500,7 +500,7 @@
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -553,11 +553,11 @@
             "type": "i64"
           },
           {
-            "name": "targetRewardsBp",
+            "name": "targetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "targetVotingBp",
+            "name": "targetVotingPct",
             "type": "u16"
           },
           {
@@ -831,7 +831,7 @@
             "type": "i64"
           },
           {
-            "name": "disableRewardsBp",
+            "name": "disableRewards",
             "type": "bool"
           }
         ]
@@ -867,11 +867,11 @@
             "type": "publicKey"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -891,7 +891,7 @@
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -994,6 +994,21 @@
       "code": 6011,
       "name": "InvalidURI",
       "msg": "Invalid URI"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidNamespace",
+      "msg": "Invalid Namespace"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidLockup",
+      "msg": "Invalid Lockup"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidVoteRecord",
+      "msg": "Invalid Vote Record"
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,13 +159,13 @@ export class VeTokenSDK {
   txUpdateNamespace(
     securityCouncil: PublicKey,
     reviewCouncil: PublicKey,
-    lockupDefaultTargetRewardsBp: number,
-    lockupDefaultTargetVotingBp: number,
+    lockupDefaultTargetRewardsPct: number,
+    lockupDefaultTargetVotingPct: number,
     lockupMinDuration: BN,
     lockupMinAmount: BN,
     lockupMaxSaturation: BN,
     proposalMinVotingPowerForQuorum: BN,
-    proposalMinPassBp: number,
+    proposalMinPassPct: number,
     proposalCanUpdateAfterVotes: boolean
   ) {
     const ix = updateNamespace(
@@ -173,13 +173,13 @@ export class VeTokenSDK {
         args: {
           securityCouncil,
           reviewCouncil,
-          lockupDefaultTargetRewardsBp,
-          lockupDefaultTargetVotingBp,
+          lockupDefaultTargetRewardsPct,
+          lockupDefaultTargetVotingPct,
           lockupMinDuration,
           lockupMinAmount,
           lockupMaxSaturation,
           proposalMinVotingPowerForQuorum,
-          proposalMinPassBp,
+          proposalMinPassPct,
           proposalCanUpdateAfterVotes,
         },
       },
@@ -216,7 +216,7 @@ export class VeTokenSDK {
     const lockup = this.pdaLockup(owner);
     const ix = stakeTo(
       {
-        args: { amount, endTs, disableRewardsBp: true },
+        args: { amount, endTs, disableRewards: true },
       },
       {
         securityCouncil: this.securityCouncil,

--- a/src/types/vetoken.ts
+++ b/src/types/vetoken.ts
@@ -476,11 +476,11 @@ export type Vetoken = {
             "type": "i64"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -500,7 +500,7 @@ export type Vetoken = {
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -553,11 +553,11 @@ export type Vetoken = {
             "type": "i64"
           },
           {
-            "name": "targetRewardsBp",
+            "name": "targetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "targetVotingBp",
+            "name": "targetVotingPct",
             "type": "u16"
           },
           {
@@ -831,7 +831,7 @@ export type Vetoken = {
             "type": "i64"
           },
           {
-            "name": "disableRewardsBp",
+            "name": "disableRewards",
             "type": "bool"
           }
         ]
@@ -867,11 +867,11 @@ export type Vetoken = {
             "type": "publicKey"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -891,7 +891,7 @@ export type Vetoken = {
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -994,6 +994,21 @@ export type Vetoken = {
       "code": 6011,
       "name": "InvalidURI",
       "msg": "Invalid URI"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidNamespace",
+      "msg": "Invalid Namespace"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidLockup",
+      "msg": "Invalid Lockup"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidVoteRecord",
+      "msg": "Invalid Vote Record"
     }
   ]
 };
@@ -1476,11 +1491,11 @@ export const IDL: Vetoken = {
             "type": "i64"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -1500,7 +1515,7 @@ export const IDL: Vetoken = {
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -1553,11 +1568,11 @@ export const IDL: Vetoken = {
             "type": "i64"
           },
           {
-            "name": "targetRewardsBp",
+            "name": "targetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "targetVotingBp",
+            "name": "targetVotingPct",
             "type": "u16"
           },
           {
@@ -1831,7 +1846,7 @@ export const IDL: Vetoken = {
             "type": "i64"
           },
           {
-            "name": "disableRewardsBp",
+            "name": "disableRewards",
             "type": "bool"
           }
         ]
@@ -1867,11 +1882,11 @@ export const IDL: Vetoken = {
             "type": "publicKey"
           },
           {
-            "name": "lockupDefaultTargetRewardsBp",
+            "name": "lockupDefaultTargetRewardsPct",
             "type": "u16"
           },
           {
-            "name": "lockupDefaultTargetVotingBp",
+            "name": "lockupDefaultTargetVotingPct",
             "type": "u16"
           },
           {
@@ -1891,7 +1906,7 @@ export const IDL: Vetoken = {
             "type": "u64"
           },
           {
-            "name": "proposalMinPassBp",
+            "name": "proposalMinPassPct",
             "type": "u16"
           },
           {
@@ -1994,6 +2009,21 @@ export const IDL: Vetoken = {
       "code": 6011,
       "name": "InvalidURI",
       "msg": "Invalid URI"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidNamespace",
+      "msg": "Invalid Namespace"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidLockup",
+      "msg": "Invalid Lockup"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidVoteRecord",
+      "msg": "Invalid Vote Record"
     }
   ]
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -454,7 +454,7 @@ describe("stake", async () => {
       assert(lockup);
       assert(lockup.amount.eq(new BN(400 * 1e6)));
       assert(lockup.endTs.eq(endTs));
-      assert(lockup.targetRewardsBp !== 0);
+      assert(lockup.targetRewardsPct !== 0);
       assert(lockup.owner.equals(signers.user1.publicKey));
       assert(!lockup.startTs.eqn(0));
     });
@@ -510,7 +510,7 @@ describe("stake", async () => {
       assert(lockup.amount.eq(new BN(400 * 1e6)));
       assert(lockup.endTs.eq(endTs));
       assert(lockup.owner.equals(signers.user2.publicKey));
-      assert(lockup.targetRewardsBp === 0);
+      assert(lockup.targetRewardsPct === 0);
       assert(!lockup.startTs.eqn(0));
     });
 
@@ -631,7 +631,7 @@ describe("proposal", async () => {
       );
       assert(vr);
       expect(vr.choice).toBe(0);
-      expect(vr.votingPower.toNumber()).toBe(8219178); // TODO: this needs to be checked from the ts's voting power calculation
+      expect(vr.votingPower.toNumber()).toBe(484094052); // TODO: this needs to be checked from the ts's voting power calculation
     });
   });
 });


### PR DESCRIPTION
<img width="709" alt="image" src="https://github.com/magicoss/vetoken/assets/89176731/33cf6b2c-a5cb-43a7-893d-0240f170f3eb">


- Added a few more validation so that we don't get overflow
- Changed the basis points (bp) to percent (pct) so that it's easier to fit in more multiplier for the target voting power and rewards