### PR TITLE
Remove proposal status and tighten up some config

### DIFF
--- a/programs/vetoken/src/ins_v1/init_namespace.rs
+++ b/programs/vetoken/src/ins_v1/init_namespace.rs
@@ -43,7 +43,7 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, InitNamespace<'info>>) -> R
     ns.lockup_min_duration = 86400 * 14; // 14 day in seconds
     ns.lockup_min_amount = 10 * 1_000_000; // ui amount is 10 assuming 6 decimals
     ns.lockup_max_saturation = 86400 * 365 * 4; // 4 years in seconds
-    ns.proposal_min_voting_power_for_quorum = 10 * 1_000_000; // minimum participation voting power
+    ns.proposal_min_voting_power_for_quorum = 10 * 1_000_000; // minimum participation voting power, please change this
     ns.proposal_min_pass_pct = 60; // 60%, the population is total_votes
     ns.proposal_can_update_after_votes = false;
 

--- a/programs/vetoken/src/ins_v1/init_proposal.rs
+++ b/programs/vetoken/src/ins_v1/init_proposal.rs
@@ -47,7 +47,6 @@ pub fn handle<'info>(
     proposal.uri = args.uri;
     proposal.start_ts = args.start_ts;
     proposal.end_ts = args.end_ts;
-    proposal.status = Proposal::STATUS_CREATED;
     proposal.owner = ctx.accounts.review_council.key();
     proposal.nonce = ns.proposal_nonce;
 

--- a/programs/vetoken/src/ins_v1/update_namespace.rs
+++ b/programs/vetoken/src/ins_v1/update_namespace.rs
@@ -44,7 +44,7 @@ pub fn handle<'info>(
     ns.lockup_max_saturation = args.lockup_max_saturation;
     ns.proposal_min_voting_power_for_quorum = args.proposal_min_voting_power_for_quorum;
     ns.proposal_min_pass_pct = args.proposal_min_pass_pct;
-    ns.proposal_can_update_after_votes = args.proposal_can_update_after_votes;
+    ns.proposal_can_update_after_votes = false; // we don't allow this to be updated yet
 
     if !ns.valid() {
         return Err(CustomError::InvalidNamespace.into());

--- a/programs/vetoken/src/ins_v1/update_proposal.rs
+++ b/programs/vetoken/src/ins_v1/update_proposal.rs
@@ -20,7 +20,7 @@ pub struct UpdateProposal<'info> {
     #[account(
       mut,
       has_one=ns,
-      constraint = proposal.can_update(&ns) @ CustomError::CannotUpdateProposal,
+      constraint = proposal.can_update() @ CustomError::CannotUpdateProposal,
     )]
     proposal: Box<Account<'info, Proposal>>,
 

--- a/programs/vetoken/src/ins_v1/vote.rs
+++ b/programs/vetoken/src/ins_v1/vote.rs
@@ -55,7 +55,6 @@ pub fn handle<'info>(ctx: Context<'_, '_, '_, 'info, Vote<'info>>, args: VoteArg
     let voting_power = lockup.voting_power(ns);
 
     proposal.cast_vote(args.choice, voting_power);
-    proposal.set_status(ns, None);
 
     vote_record.ns = ns.key();
     vote_record.choice = args.choice;


### PR DESCRIPTION
- Removed proposal's status related code
- Make sure that proposal_can_update_after_votes is always false (we might open this up later, but not this version)
- change from `self.start_ts <= self.end_ts` to `self.start_ts < self.end_ts` for proposal's `valid` function