### PR TITLE
Add special handling of end_ts for lockup

### DIFF
--- a/programs/vetoken/src/ins_v1/stake.rs
+++ b/programs/vetoken/src/ins_v1/stake.rs
@@ -36,7 +36,7 @@ pub struct Stake<'info> {
       seeds=[b"lockup", ns.key().as_ref(), owner.key.as_ref()],
       space= 8 + Lockup::INIT_SPACE,
       constraint = args.amount >= ns.lockup_min_amount @ CustomError::InvalidLockupAmount,
-      constraint = args.end_ts >= lockup.min_end_ts(&ns) @ CustomError::InvalidTimestamp,
+      constraint = (args.end_ts >= lockup.min_end_ts(&ns) || args.end_ts == 0) @ CustomError::InvalidTimestamp,
       bump
     )]
     lockup: Box<Account<'info, Lockup>>,

--- a/programs/vetoken/src/ins_v1/stake_to.rs
+++ b/programs/vetoken/src/ins_v1/stake_to.rs
@@ -42,7 +42,7 @@ pub struct StakeTo<'info> {
       seeds=[b"lockup", ns.key().as_ref(), owner.key().as_ref()],
       space= 8 + Lockup::INIT_SPACE,
       constraint = args.amount >= ns.lockup_min_amount @ CustomError::InvalidLockupAmount,
-      constraint = args.end_ts >= lockup.min_end_ts(&ns) @ CustomError::InvalidTimestamp,
+      constraint = (args.end_ts >= lockup.min_end_ts(&ns) || args.end_ts == 0) @ CustomError::InvalidTimestamp,
       bump
     )]
     lockup: Box<Account<'info, Lockup>>,

--- a/programs/vetoken/src/states.rs
+++ b/programs/vetoken/src/states.rs
@@ -80,8 +80,8 @@ impl Lockup {
 
     pub fn valid(&self, ns: &Namespace) -> bool {
         self.amount >= ns.lockup_min_amount
-            && self.start_ts > 0
-            && self.end_ts >= self.min_end_ts(ns)
+            && self.start_ts >= 0
+            && (self.end_ts >= self.min_end_ts(ns) || self.end_ts == 0)
             && self.end_ts >= self.start_ts
             && self.target_voting_pct >= 100
             && self.target_voting_pct <= 2500 // max 25x


### PR DESCRIPTION

To implement a special kind of stake that can be immediately unstaked. 

- relax the constraint when one needs to stake
- the voting power is carefully designed and keep the original behavior