### PR TITLE
Add `weightedStartTs` field to `Lockup` with backward compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^17.0.1"
   },
   "devDependencies": {
+    "@coral-xyz/anchor": "^0.29.0",
     "@types/bn.js": "^5.1.5",
     "solana-bankrun": "^0.3.0",
     "tsx": "^4.20.3",

--- a/programs/vetoken/src/ins_v1/stake_to.rs
+++ b/programs/vetoken/src/ins_v1/stake_to.rs
@@ -98,6 +98,7 @@ pub fn handle<'info>(
         args.end_ts,
         lockup.start_ts + (ns.lockup_max_saturation as i64),
     );
+    lockup.weighted_start_ts = lockup.start_ts;
     lockup.amount = args.amount;
     lockup.owner = ctx.accounts.owner.key();
     lockup.target_voting_pct = ns.lockup_default_target_voting_pct;

--- a/programs/vetoken/src/states.rs
+++ b/programs/vetoken/src/states.rs
@@ -65,13 +65,27 @@ pub struct Lockup {
     pub start_ts: i64,
     pub end_ts: i64,
 
+    // New field to track weighted start for voting/reward power
+    pub weighted_start_ts: i64,
+
     pub target_rewards_pct: u16, // in percent
     pub target_voting_pct: u16,  // in percent
 
-    pub _padding: [u8; 240],
+    // Reduced padding to keep total size unchanged after adding weighted_start_ts
+    pub _padding: [u8; 232],
 }
 
 impl Lockup {
+    pub const LEGACY_SIZE: usize = 8  // discriminator
+        + 32  // ns
+        + 32  // owner
+        + 8   // amount
+        + 8   // start_ts
+        + 8   // end_ts
+        + 2   // target_rewards_pct
+        + 2   // target_voting_pct
+        + 240; // legacy padding
+
     pub fn min_end_ts(&self, ns: &Namespace) -> i64 {
         ns.now()
             .checked_add(ns.lockup_min_duration)
@@ -85,6 +99,21 @@ impl Lockup {
             && (self.end_ts >= self.start_ts || self.end_ts == 0)
             && self.target_voting_pct >= 100
             && self.target_voting_pct <= 2500 // max 25x
+    }
+
+    pub fn  effective_start_ts(&self) -> i64 {
+        if self.weighted_start_ts == 0 {
+            self.start_ts
+        } else {
+            self.weighted_start_ts
+        }
+    }
+
+    pub fn normalize_weighted_start_ts(&mut self, data_len: usize) {
+        if data_len <= Self::LEGACY_SIZE && self.weighted_start_ts == 0 {
+            // Legacy accounts lacked weighted_start_ts; default to start_ts.
+            self.weighted_start_ts = self.start_ts;
+        }
     }
 
     /*
@@ -120,7 +149,7 @@ impl Lockup {
             return 0;
         }
 
-        let duration = (self.end_ts - self.start_ts) as u128;
+        let duration = (self.end_ts - self.effective_start_ts()) as u128;
         let max_voting_power = (self.amount as u128 * self.target_voting_pct as u128) / 100;
         if duration <= ns.lockup_min_duration as u128 {
             return self.amount; // minimal 100% of the amount
@@ -308,9 +337,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 1000,
                     target_voting_pct: 5000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 0, // end_ts expired, because override_now > end_ts
             ),
@@ -340,9 +370,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400 * 14,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 100,
                     target_voting_pct: 2000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 11692,
             ),
@@ -373,9 +404,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 100,
                     target_voting_pct: 2000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 0, // 0 because of the target_rewards_pct
             ),
@@ -405,9 +437,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 86400,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 100,
                     target_voting_pct: 2000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 10000, // because we just hit the minimal duration, thus only getting 100% of the amount
             ),
@@ -437,9 +470,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 1717796555 + 3600 * 24 * 180,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 100,
                     target_voting_pct: 2000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 200000, //  should be 2000%
             ),
@@ -469,9 +503,10 @@ mod tests {
                     amount: 10000,
                     start_ts: 0,
                     end_ts: 1717796555 + 3600 * 24 * 365 * 3 / 2,
+                    weighted_start_ts: 0,
                     target_rewards_pct: 100,
                     target_voting_pct: 2000,
-                    _padding: [0; 240],
+                    _padding: [0; 232],
                 },
                 200000, //  should be 20x of the amount
             ),
@@ -481,6 +516,133 @@ mod tests {
             let voting_power = lockup.voting_power(&ns);
             assert_eq!(voting_power, expected_voting_power, "{}", name);
         }
+    }
+
+    #[test]
+    fn test_weighted_start_ts_voting_power() {
+        // Test Case 1: Attack scenario - small initial stake with max lock, then large top-up near expiry
+        // Should get only ~1x multiplier due to short remaining time
+        let ns = Namespace {
+            token_mint: Pubkey::new_from_array([0; 32]),
+            deployer: Pubkey::new_from_array([0; 32]),
+            security_council: Pubkey::new_from_array([0; 32]),
+            review_council: Pubkey::new_from_array([0; 32]),
+            override_now: 0,
+            lockup_default_target_rewards_pct: 100,
+            lockup_default_target_voting_pct: 2000, // 20x max
+            lockup_min_duration: 86400 * 14,         // 14 days
+            lockup_min_amount: 1,
+            lockup_max_saturation: 86400 * 365 * 4, // 4 years
+            proposal_min_voting_power_for_quorum: 10000,
+            proposal_min_pass_pct: 60,
+            proposal_can_update_after_votes: false,
+            lockup_amount: 0,
+            proposal_nonce: 0,
+            _padding: [0; 240],
+        };
+
+        // Simulate: 1 token locked for 4 years, then after 3.9 years add 999,999 tokens
+        // weighted_start_ts should be very close to end_ts, giving minimal multiplier
+        let four_years = 86400 * 365 * 4;
+        let lockup_attack = Lockup {
+            ns: Pubkey::new_from_array([0; 32]),
+            owner: Pubkey::new_from_array([0; 32]),
+            amount: 1_000_000,
+            start_ts: 0,
+            end_ts: four_years,
+            // After top-up: old_tw = 1 * 4y, added_tw = 999999 * 0.1y
+            // new_tw ≈ 100,003 years, duration ≈ 0.100003 years
+            weighted_start_ts: four_years - 100_003, // ~3.9 years from T0
+            target_rewards_pct: 100,
+            target_voting_pct: 2000,
+            _padding: [0; 232],
+        };
+        let vp_attack = lockup_attack.voting_power(&ns);
+        // With only ~0.1 year duration, should be close to 1x (amount itself)
+        assert!(
+            vp_attack < 1_100_000,
+            "Attack case should yield < 1.1x, got {}",
+            vp_attack
+        );
+
+        // Test Case 2: Normal user locks full amount for 4 years from start
+        // Should get full 20x multiplier
+        let lockup_normal = Lockup {
+            ns: Pubkey::new_from_array([0; 32]),
+            owner: Pubkey::new_from_array([0; 32]),
+            amount: 1_000_000,
+            start_ts: 0,
+            end_ts: four_years,
+            weighted_start_ts: 0, // Same as start_ts
+            target_rewards_pct: 100,
+            target_voting_pct: 2000,
+            _padding: [0; 232],
+        };
+        let vp_normal = lockup_normal.voting_power(&ns);
+        assert_eq!(
+            vp_normal, 20_000_000,
+            "Normal 4-year lock should get 20x"
+        );
+
+        // Test Case 3: Gradual top-ups - 3 equal stakes over 2 years
+        // Average lock time ~3 years, should get ~15x
+        let lockup_gradual = Lockup {
+            ns: Pubkey::new_from_array([0; 32]),
+            owner: Pubkey::new_from_array([0; 32]),
+            amount: 300_000,
+            start_ts: 0,
+            end_ts: four_years,
+            // Weighted start should be around T0 + 1 year (average of 0, 1, 2 years)
+            weighted_start_ts: four_years - (86400 * 365 * 3), // 3-year duration
+            target_rewards_pct: 100,
+            target_voting_pct: 2000,
+            _padding: [0; 232],
+        };
+        let vp_gradual = lockup_gradual.voting_power(&ns);
+        // 3 years is 75% of max saturation, should be between 100% and 2000%
+        // Linear interpolation: 100% + (2000% - 100%) * (3y - 14d) / (4y - 14d) ≈ 1425%
+        assert!(
+            vp_gradual >= 4_000_000 && vp_gradual <= 5_000_000,
+            "Gradual case should yield 13x-17x, got {}x",
+            vp_gradual / 300_000
+        );
+
+        // Test Case 4: weighted_start_ts = 0 fallback to start_ts (legacy compatibility)
+        let lockup_legacy = Lockup {
+            ns: Pubkey::new_from_array([0; 32]),
+            owner: Pubkey::new_from_array([0; 32]),
+            amount: 10_000,
+            start_ts: 0,
+            end_ts: 86400 * 365, // 1 year
+            weighted_start_ts: 0, // Should use start_ts
+            target_rewards_pct: 100,
+            target_voting_pct: 2000,
+            _padding: [0; 232],
+        };
+        let vp_legacy = lockup_legacy.voting_power(&ns);
+        // 1 year = 25% of 4 years, should get ~5.75x
+        assert!(
+            vp_legacy >= 50_000 && vp_legacy <= 60_000,
+            "Legacy case (1y) should yield ~5-6x, got {}",
+            vp_legacy
+        );
+
+        // Test Case 5: Minimum duration with weighted_start_ts
+        // Should return 100% of the amount regardless of weighted_start_ts
+        let min_duration = 86400 * 14;
+        let lockup_min = Lockup {
+            ns: Pubkey::new_from_array([0; 32]),
+            owner: Pubkey::new_from_array([0; 32]),
+            amount: 10_000,
+            start_ts: 0,
+            end_ts: min_duration,
+            weighted_start_ts: 0,
+            target_rewards_pct: 100,
+            target_voting_pct: 2000,
+            _padding: [0; 232],
+        };
+        let vp_min = lockup_min.voting_power(&ns);
+        assert_eq!(vp_min, 10_000, "Min duration should yield 1x (100%)");
     }
 
     #[test]

--- a/programs/vetoken/src/states.rs
+++ b/programs/vetoken/src/states.rs
@@ -65,17 +65,20 @@ pub struct Lockup {
     pub start_ts: i64,
     pub end_ts: i64,
 
-    // New field to track weighted start for voting/reward power
-    pub weighted_start_ts: i64,
-
     pub target_rewards_pct: u16, // in percent
     pub target_voting_pct: u16,  // in percent
 
-    // Reduced padding to keep total size unchanged after adding weighted_start_ts
+    // New field to track weighted start for voting/reward power
+    // Added after existing fields for backward compatibility
+    pub weighted_start_ts: i64,
+    
+    // Padding at the end for future field additions
+    // Reduced from 240 to 232 bytes to accommodate weighted_start_ts
     pub _padding: [u8; 232],
 }
 
 impl Lockup {
+    // Legacy size before adding weighted_start_ts field
     pub const LEGACY_SIZE: usize = 8  // discriminator
         + 32  // ns
         + 32  // owner
@@ -84,7 +87,7 @@ impl Lockup {
         + 8   // end_ts
         + 2   // target_rewards_pct
         + 2   // target_voting_pct
-        + 240; // legacy padding
+        + 240; // legacy padding (total: 340 bytes)
 
     pub fn min_end_ts(&self, ns: &Namespace) -> i64 {
         ns.now()

--- a/src/generated/accounts/Lockup.ts
+++ b/src/generated/accounts/Lockup.ts
@@ -10,10 +10,10 @@ export interface LockupFields {
   amount: BN
   startTs: BN
   endTs: BN
-  weightedStartTs: BN
   targetRewardsPct: number
   targetVotingPct: number
   padding: Array<number>
+  weightedStartTs: BN
 }
 
 export interface LockupJSON {
@@ -22,10 +22,10 @@ export interface LockupJSON {
   amount: string
   startTs: string
   endTs: string
-  weightedStartTs: string
   targetRewardsPct: number
   targetVotingPct: number
   padding: Array<number>
+  weightedStartTs: string
 }
 
 export class Lockup {
@@ -34,10 +34,10 @@ export class Lockup {
   readonly amount: BN
   readonly startTs: BN
   readonly endTs: BN
-  readonly weightedStartTs: BN
   readonly targetRewardsPct: number
   readonly targetVotingPct: number
   readonly padding: Array<number>
+  readonly weightedStartTs: BN
 
   static readonly discriminator = Buffer.from([1, 45, 32, 32, 57, 81, 88, 67])
 
@@ -47,10 +47,10 @@ export class Lockup {
     borsh.u64("amount"),
     borsh.i64("startTs"),
     borsh.i64("endTs"),
-    borsh.i64("weightedStartTs"),
     borsh.u16("targetRewardsPct"),
     borsh.u16("targetVotingPct"),
     borsh.array(borsh.u8(), 232, "padding"),
+    borsh.i64("weightedStartTs"),
   ])
 
   constructor(fields: LockupFields) {
@@ -59,10 +59,10 @@ export class Lockup {
     this.amount = fields.amount
     this.startTs = fields.startTs
     this.endTs = fields.endTs
-    this.weightedStartTs = fields.weightedStartTs
     this.targetRewardsPct = fields.targetRewardsPct
     this.targetVotingPct = fields.targetVotingPct
     this.padding = fields.padding
+    this.weightedStartTs = fields.weightedStartTs
   }
 
   static async fetch(
@@ -114,10 +114,10 @@ export class Lockup {
       amount: dec.amount,
       startTs: dec.startTs,
       endTs: dec.endTs,
-      weightedStartTs: dec.weightedStartTs,
       targetRewardsPct: dec.targetRewardsPct,
       targetVotingPct: dec.targetVotingPct,
       padding: dec.padding,
+      weightedStartTs: dec.weightedStartTs,
     })
   }
 
@@ -128,10 +128,10 @@ export class Lockup {
       amount: this.amount.toString(),
       startTs: this.startTs.toString(),
       endTs: this.endTs.toString(),
-      weightedStartTs: this.weightedStartTs.toString(),
       targetRewardsPct: this.targetRewardsPct,
       targetVotingPct: this.targetVotingPct,
       padding: this.padding,
+      weightedStartTs: this.weightedStartTs.toString(),
     }
   }
 
@@ -142,10 +142,10 @@ export class Lockup {
       amount: new BN(obj.amount),
       startTs: new BN(obj.startTs),
       endTs: new BN(obj.endTs),
-      weightedStartTs: new BN(obj.weightedStartTs),
       targetRewardsPct: obj.targetRewardsPct,
       targetVotingPct: obj.targetVotingPct,
       padding: obj.padding,
+      weightedStartTs: new BN(obj.weightedStartTs),
     })
   }
 }

--- a/src/generated/accounts/Lockup.ts
+++ b/src/generated/accounts/Lockup.ts
@@ -10,6 +10,7 @@ export interface LockupFields {
   amount: BN
   startTs: BN
   endTs: BN
+  weightedStartTs: BN
   targetRewardsPct: number
   targetVotingPct: number
   padding: Array<number>
@@ -21,6 +22,7 @@ export interface LockupJSON {
   amount: string
   startTs: string
   endTs: string
+  weightedStartTs: string
   targetRewardsPct: number
   targetVotingPct: number
   padding: Array<number>
@@ -32,6 +34,7 @@ export class Lockup {
   readonly amount: BN
   readonly startTs: BN
   readonly endTs: BN
+  readonly weightedStartTs: BN
   readonly targetRewardsPct: number
   readonly targetVotingPct: number
   readonly padding: Array<number>
@@ -44,9 +47,10 @@ export class Lockup {
     borsh.u64("amount"),
     borsh.i64("startTs"),
     borsh.i64("endTs"),
+    borsh.i64("weightedStartTs"),
     borsh.u16("targetRewardsPct"),
     borsh.u16("targetVotingPct"),
-    borsh.array(borsh.u8(), 240, "padding"),
+    borsh.array(borsh.u8(), 232, "padding"),
   ])
 
   constructor(fields: LockupFields) {
@@ -55,6 +59,7 @@ export class Lockup {
     this.amount = fields.amount
     this.startTs = fields.startTs
     this.endTs = fields.endTs
+    this.weightedStartTs = fields.weightedStartTs
     this.targetRewardsPct = fields.targetRewardsPct
     this.targetVotingPct = fields.targetVotingPct
     this.padding = fields.padding
@@ -109,6 +114,7 @@ export class Lockup {
       amount: dec.amount,
       startTs: dec.startTs,
       endTs: dec.endTs,
+      weightedStartTs: dec.weightedStartTs,
       targetRewardsPct: dec.targetRewardsPct,
       targetVotingPct: dec.targetVotingPct,
       padding: dec.padding,
@@ -122,6 +128,7 @@ export class Lockup {
       amount: this.amount.toString(),
       startTs: this.startTs.toString(),
       endTs: this.endTs.toString(),
+      weightedStartTs: this.weightedStartTs.toString(),
       targetRewardsPct: this.targetRewardsPct,
       targetVotingPct: this.targetVotingPct,
       padding: this.padding,
@@ -135,6 +142,7 @@ export class Lockup {
       amount: new BN(obj.amount),
       startTs: new BN(obj.startTs),
       endTs: new BN(obj.endTs),
+      weightedStartTs: new BN(obj.weightedStartTs),
       targetRewardsPct: obj.targetRewardsPct,
       targetVotingPct: obj.targetVotingPct,
       padding: obj.padding,

--- a/src/generated/accounts/Lockup.ts
+++ b/src/generated/accounts/Lockup.ts
@@ -49,8 +49,8 @@ export class Lockup {
     borsh.i64("endTs"),
     borsh.u16("targetRewardsPct"),
     borsh.u16("targetVotingPct"),
-    borsh.array(borsh.u8(), 232, "padding"),
     borsh.i64("weightedStartTs"),
+    borsh.array(borsh.u8(), 232, "padding"),
   ])
 
   constructor(fields: LockupFields) {

--- a/src/idl/vetoken.json
+++ b/src/idl/vetoken.json
@@ -645,10 +645,6 @@
             "type": "i64"
           },
           {
-            "name": "weightedStartTs",
-            "type": "i64"
-          },
-          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -664,6 +660,10 @@
                 232
               ]
             }
+          },
+          {
+            "name": "weightedStartTs",
+            "type": "i64"
           }
         ]
       }

--- a/src/idl/vetoken.json
+++ b/src/idl/vetoken.json
@@ -645,6 +645,10 @@
             "type": "i64"
           },
           {
+            "name": "weightedStartTs",
+            "type": "i64"
+          },
+          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -657,7 +661,7 @@
             "type": {
               "array": [
                 "u8",
-                240
+                232
               ]
             }
           }

--- a/src/types/vetoken.ts
+++ b/src/types/vetoken.ts
@@ -645,10 +645,6 @@ export type Vetoken = {
             "type": "i64"
           },
           {
-            "name": "weightedStartTs",
-            "type": "i64"
-          },
-          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -664,6 +660,10 @@ export type Vetoken = {
                 232
               ]
             }
+          },
+          {
+            "name": "weightedStartTs",
+            "type": "i64"
           }
         ]
       }
@@ -1768,10 +1768,6 @@ export const IDL: Vetoken = {
             "type": "i64"
           },
           {
-            "name": "weightedStartTs",
-            "type": "i64"
-          },
-          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -1787,6 +1783,10 @@ export const IDL: Vetoken = {
                 232
               ]
             }
+          },
+          {
+            "name": "weightedStartTs",
+            "type": "i64"
           }
         ]
       }

--- a/src/types/vetoken.ts
+++ b/src/types/vetoken.ts
@@ -645,6 +645,10 @@ export type Vetoken = {
             "type": "i64"
           },
           {
+            "name": "weightedStartTs",
+            "type": "i64"
+          },
+          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -657,7 +661,7 @@ export type Vetoken = {
             "type": {
               "array": [
                 "u8",
-                240
+                232
               ]
             }
           }
@@ -1764,6 +1768,10 @@ export const IDL: Vetoken = {
             "type": "i64"
           },
           {
+            "name": "weightedStartTs",
+            "type": "i64"
+          },
+          {
             "name": "targetRewardsPct",
             "type": "u16"
           },
@@ -1776,7 +1784,7 @@ export const IDL: Vetoken = {
             "type": {
               "array": [
                 "u8",
-                240
+                232
               ]
             }
           }


### PR DESCRIPTION
- Introduces `weightedStartTs` to enable more accurate voting power and reward calculations.
- Ensures compatibility with legacy accounts via fallback mechanisms.
- Updates padding to maintain consistent data size.




# Weighted Start Timestamp Calculation Verification

This document provides a detailed verification of the `weighted_start_ts` calculation when extending an existing lockup with additional tokens.

## Overview

When a user extends an existing lockup by:
1. Adding more tokens
2. Extending the end time
3. Or both

The contract calculates a new `weighted_start_ts` that represents the time-weighted average start time across all locked tokens. This ensures fair calculation of voting power and rewards.

## Transaction Details

**Transaction Signature**: `9jLyCTuk7wCNakbg8mC7cARSnFvvNUfpJnXZYo6wevjportHE3RMbxL8st88MA6kPYtWeMoaL5quPiLiYqXao6i`

**Explorer Link**: https://explorer.solana.com/tx/9jLyCTuk7wCNakbg8mC7cARSnFvvNUfpJnXZYo6wevjportHE3RMbxL8st88MA6kPYtWeMoaL5quPiLiYqXao6i?cluster=devnet

## Input Data

### Before Extension

| Field | Value | Description |
|-------|-------|-------------|
| `amount` | 60,200,000,000 | 60.2 tokens (raw units) |
| `start_ts` | 1767950390 | 2026-01-09T09:19:50.000Z |
| `end_ts` | 1775000000 | 2026-03-31T23:33:20.000Z |
| `weighted_start_ts` | 0 | Legacy data (no field) |
| `duration` | 7,049,610 seconds | 81.59 days |

### Extension Operation

| Field | Value | Description |
|-------|-------|-------------|
| `delta_amount` | 100,000,000,000 | 100 tokens added |
| `new_end_ts` | 1777592000 | 2026-04-30T23:33:20.000Z |
| `now` (transaction time) | 1768294100 | 2026-01-13T08:48:20.000Z |

### After Extension

| Field | Value | Description |
|-------|-------|-------------|
| `amount` | 160,200,000,000 | 160.2 tokens total |
| `start_ts` | 1767950390 | Unchanged |
| `end_ts` | 1777592000 | Extended by 30 days |
| `weighted_start_ts` | 1768164941 | **To be verified** |
| `duration` | 9,641,610 seconds | 111.59 days |

## Calculation Algorithm

The weighted start timestamp is calculated using the **time-weighted area conservation** principle:

```
weighted_start_ts = end_ts - (total_time_weighted_area / total_amount)
```

Where the total time-weighted area consists of three components:

1. **Old time-weighted area**: Original tokens × original duration
2. **Extension area**: Original tokens × extension duration
3. **Added area**: New tokens × remaining duration

## Step-by-Step Calculation

### Step 1: Calculate Old Time-Weighted Area

The original lockup's time-weighted area:

```
old_duration = old_end_ts - effective_start
             = 1775000000 - 1767950390
             = 7,049,610 seconds
             = 81.59 days

old_tw = old_amount × old_duration
       = 60,200,000,000 × 7,049,610
       = 424,386,522,000,000,000
```

**Explanation**: This represents the "token-seconds" that the original 60.2 tokens contributed over their initial lockup period.

### Step 2: Calculate Extension Area

When we extend the end time, the existing tokens gain additional time:

```
extension = new_end_ts - old_end_ts
          = 1777592000 - 1775000000
          = 2,592,000 seconds
          = 30.00 days

extension_tw = old_amount × extension
             = 60,200,000,000 × 2,592,000
             = 156,038,400,000,000,000
```

**Explanation**: The original 60.2 tokens are now locked for an additional 30 days, contributing this additional time-weighted area.

### Step 3: Calculate Added Token Area

The newly added tokens contribute from the transaction time until the end:

```
remaining = new_end_ts - now
          = 1777592000 - 1768294100
          = 9,297,900 seconds
          = 107.61 days

added_tw = delta_amount × remaining
         = 100,000,000,000 × 9,297,900
         = 929,790,000,000,000,000
```

**Explanation**: The 100 new tokens are locked from the transaction time (2026-01-13) until the end (2026-04-30), contributing this time-weighted area.

### Step 4: Calculate Total Time-Weighted Area

Sum all three components:

```
new_tw = old_tw + extension_tw + added_tw
       = 424,386,522,000,000,000
       + 156,038,400,000,000,000
       + 929,790,000,000,000,000
       = 1,510,214,922,000,000,000
```

### Step 5: Calculate Weighted Start Timestamp

Derive the weighted start time from the total area:

```
average_duration = new_tw / new_amount
                 = 1,510,214,922,000,000,000 / 160,200,000,000
                 = 9,427,059 seconds
                 = 109.11 days

weighted_start_ts = new_end_ts - average_duration
                  = 1777592000 - 9,427,059
                  = 1768164941
```

**Result**: 2026-01-11T20:55:41.000Z

## Verification Result

| Source | Value | Match |
|--------|-------|-------|
| **Contract Calculation** | 1768164941 | ✅ |
| **Our Calculation** | 1768164941 | ✅ |
| **Difference** | 0 seconds | **Perfect Match!** |

## Physical Interpretation

The weighted start timestamp represents the **time-weighted average** of when all tokens were locked:

### Visual Timeline

```
2026-01-09          2026-01-11          2026-01-13          2026-03-31    2026-04-30
    |                   |                   |                   |             |
    |<--- 60.2 tokens locked here ----------|--- extended ----->|             |
    |                   |                   |                                 |
    |                   |                   |<--- 100 tokens added here ----->|
    |                   |                                                     |
    |                   |<--- Weighted average start (160.2 tokens) --------->|
    |                                                                         |
  Original            Weighted              Transaction         Old End     New End
   Start               Start                  Time                          
```

### Breakdown

1. **Original 60.2 tokens**: 
   - Locked from 2026-01-09 to 2026-03-31 (81.59 days)
   - Extended to 2026-04-30 (additional 30 days)
   - Total contribution: 111.59 days

2. **New 100 tokens**:
   - Added on 2026-01-13
   - Locked until 2026-04-30
   - Contribution: 107.61 days

3. **Weighted Average**:
   - Equivalent to 160.2 tokens locked from **2026-01-11** to 2026-04-30
   - Average duration: **109.11 days**

## Mathematical Formula

The general formula for weighted start timestamp calculation:

```rust
let effective_start = lockup.effective_start_ts();
let old_duration = lockup.end_ts - effective_start;
let old_tw = old_amount * old_duration;

let extension = new_end_ts - lockup.end_ts;
let extension_tw = old_amount * extension;

let remaining = new_end_ts - now;
let added_tw = delta_amount * remaining;

let new_tw = old_tw + extension_tw + added_tw;
let new_weighted_start = new_end_ts - (new_tw / new_amount);
```
